### PR TITLE
Refactor IU Orders: hide columns and save columns sizes

### DIFF
--- a/src/app/modules/orders/components/orders-overview/orders-overview.component.html
+++ b/src/app/modules/orders/components/orders-overview/orders-overview.component.html
@@ -13,17 +13,9 @@
     columnResizeMode="expand"
     [scrollable]="true"
     scrollHeight="60vh"
-    [tableStyle]="{'min-width': '20%','border-spacing': '1px'}">
-    <ng-template #caption>
-      <p-multiselect 
-        display="chip" 
-        [options]="cols" 
-        [(ngModel)]="selectedColumns" 
-        optionLabel="header"
-        selectedItemsLabel="{0} columns selected"
-        [style]="{ 'min-width': '250px', 'font-size': '14px', 'line-height': '16.8px' }" 
-        placeholder="Choose Columns" />
-    </ng-template>
+    [tableStyle]="{'min-width': '20%','border-spacing': '1px'}"
+    stateStorage="local"
+    stateKey="orders-table-state">
     <ng-template #header let-columns>
       <tr>
         <th scope="col"></th>
@@ -37,7 +29,12 @@
         </th>
       </tr>
       <tr>
-        <th scope="col" class="thead-bg-blue"></th>
+        <th id="hide-columns" class="thead-bg-blue">
+          <p-multiselect [options]="cols" [(ngModel)]="selectedColumns" optionLabel="header"
+            selectedItemsLabel="Hide columns"
+            placeholder="Choose Columns" 
+            [maxSelectedLabels]="0"/>
+        </th>
         <th scope="col" *ngFor="let col of columns; let i = index" [pSortableColumn]="col.field" pResizableColumn class="thead">{{
           col.header }} <p-sortIcon [field]="col.field" />
         </th>


### PR DESCRIPTION
- moved the hide columns to the empty cell
- Save column sizes when changing