### PR TITLE
fix : forms title

### DIFF
--- a/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.html
+++ b/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.html
@@ -5,7 +5,7 @@
                 <label for="titleName" class="block mb-2">
                     {{ 'TITLE.FORM.NEW_TITLE' | translate }}
                 </label>
-                <input pInputText type="text" id="titleName" formControlName="name" autocomplete="off"
+                <input #titleInput pInputText type="text" id="titleName" formControlName="name" autocomplete="off"
                     [attr.aria-invalid]="createTitleForm.get('name')?.invalid"
                     [attr.aria-describedby]="createTitleForm.get('name')?.invalid ? 'titleError' : null"
                     class="w-full" />
@@ -16,12 +16,12 @@
             </div>
 
             <div class="flex justify-content-end gap-2 mt-4">
-                <p-button type="button" class="cancel" size="small" [label]="'BUTTONS.CANCEL' | translate"
-                    icon="pi pi-times" iconPos="left" (onClick)="closeModal()" [disabled]="isLoading" />
-
                 <p-button type="submit" class="save" size="small" [label]="'BUTTONS.SAVE' | translate"
                     icon="pi pi-check" iconPos="left" [loading]="isLoading"
                     [disabled]="createTitleForm.invalid || isLoading" />
+
+                <p-button type="button" class="cancel" size="small" [label]="'BUTTONS.CANCEL' | translate"
+                    icon="pi pi-times" iconPos="left" (onClick)="closeModal()" [disabled]="isLoading" />
             </div>
         </div>
     </form>
@@ -35,12 +35,13 @@
         </p>
 
         <div class="flex justify-content-end gap-2">
-            <p-button type="button" class="cancel" size="small" [label]="'BUTTONS.CANCEL' | translate"
-                icon="pi pi-times" iconPos="left" (onClick)="closeModal()" [disabled]="isLoading" />
-
             <p-button type="button" class="delete" size="small" [label]="'BUTTONS.DELETE' | translate"
                 icon="pi pi-trash" iconPos="left" (onClick)="onDeleteConfirm()" severity="danger" [loading]="isLoading"
                 [disabled]="isLoading" />
+
+            <p-button type="button" class="cancel" size="small" [label]="'BUTTONS.CANCEL' | translate"
+                icon="pi pi-times" iconPos="left" (onClick)="closeModal()" [disabled]="isLoading" />
+
         </div>
     </div>
 </ng-template>

--- a/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.ts
+++ b/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.ts
@@ -125,7 +125,7 @@ export class TitleModalComponent implements OnInit {
   public focusInputIfNeeded() {
     if (this.isCreateMode && this.titleInput) {
       setTimeout(() => {
-        if (this.titleInput && this.titleInput.nativeElement) {
+        if (this.titleInput?.nativeElement) {
           this.titleInput.nativeElement.focus(); 
         }
       }, 150); 

--- a/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.ts
+++ b/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { TitleUtils } from '../../utils/title-utils';
 import { catchError, switchMap, finalize } from 'rxjs/operators';
 import { of } from 'rxjs';
+import { ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-title-modal',
@@ -13,7 +14,7 @@ import { of } from 'rxjs';
 
 export class TitleModalComponent implements OnInit {
   private readonly titleUtils = inject(TitleUtils);
-  
+  @ViewChild('titleInput') titleInput!: ElementRef<HTMLInputElement>;
   @Input() modalType: 'create' | 'delete' = 'create';
   @Input() titleToDelete: number | null = null;
   @Input() titleName: string | null = null;
@@ -120,5 +121,15 @@ export class TitleModalComponent implements OnInit {
 
   onCancel(): void {
     this.handleClose();
+  }
+
+  public focusInputIfNeeded() {
+    if (this.isCreateMode && this.titleInput) {
+      setTimeout(() => {
+        if (this.titleInput && this.titleInput.nativeElement) {
+          this.titleInput.nativeElement.focus(); 
+        }
+      }, 150); 
+    }
   }
 }

--- a/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.ts
+++ b/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.ts
@@ -1,9 +1,8 @@
-import { Component, EventEmitter, Output, inject, OnInit, Input } from '@angular/core';
+import { Component, EventEmitter, Output, inject, OnInit, Input, ViewChild, ElementRef} from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { TitleUtils } from '../../utils/title-utils';
 import { catchError, switchMap, finalize } from 'rxjs/operators';
 import { of } from 'rxjs';
-import { ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-title-modal',

--- a/src/app/modules/master-data/components/title/components/title-table/title-table.component.html
+++ b/src/app/modules/master-data/components/title/components/title-table/title-table.component.html
@@ -19,12 +19,14 @@
           : ('TITLE.DELETE.CONFIRMATION' | translate)" 
         [modal]="true" 
         [(visible)]="visibleModal" 
+        (onShow)="onDialogShow()"
       >
         <app-title-modal
           [modalType]="modalType"
           [titleName]="titleName"
           [titleToDelete]="selectedTitle"
           (isVisibleModal)="onModalVisibilityChange($event)"
+          #titleModal
         ></app-title-modal>
       </p-dialog>
     </div>

--- a/src/app/modules/master-data/components/title/components/title-table/title-table.component.ts
+++ b/src/app/modules/master-data/components/title/components/title-table/title-table.component.ts
@@ -8,6 +8,7 @@ import { TitleService } from '../../../../../../Services/title.service';
 import { TitleUtils } from '../../utils/title-utils';
 import { Title } from '../../../../../../Entities/title';
 import { TitleStateService } from '../../utils/title-state.service';
+import { TitleModalComponent } from '../title-modal/title-modal.component';
 
 @Component({
   selector: 'app-title-table',
@@ -22,7 +23,7 @@ export class TitleTableComponent implements OnInit, OnDestroy, OnChanges {
   modalType: 'create' | 'delete' = 'create';
   selectedTitle: number | null = null;
   titleName: string = '';
-
+  @ViewChild('titleModal') titleModalComponent!: TitleModalComponent;
   handleTableEvents(event: { type: 'create' | 'delete', data?: any }): void {
     this.modalType = event.type;
     if (event.type === 'delete' && event.data) {
@@ -140,16 +141,21 @@ export class TitleTableComponent implements OnInit, OnDestroy, OnChanges {
         console.error('Error al cargar título:', err);
       }
     });
-}
-
-onVisibleModal(visible: boolean){
-  this.visibleModal = visible;
-}
-
-onModalVisibilityChange(visible: boolean): void {
-  this.visibleModal = visible;
-  if(!visible) {
-    this.selectedTitle = null;
   }
-}
+
+  onVisibleModal(visible: boolean) {
+    this.visibleModal = visible;
+  }
+
+  onModalVisibilityChange(visible: boolean): void {
+    this.visibleModal = visible;
+    if (!visible) {
+      this.selectedTitle = null;
+    }
+  }
+  onDialogShow() {
+    if (this.modalType === 'create' && this.titleModalComponent) {
+      this.titleModalComponent.focusInputIfNeeded();
+    }
+  }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -639,12 +639,12 @@
       "TITLE_LABEL_REQUIRED": "Titel ist erforderlich"
     },
     "DELETE": {
-      "CONFIRMATION": "Titel Löschen",
+      "CONFIRMATION": "Titel löschen",
       "CONFIRM_QUESTION": "Sind Sie sicher, dass Sie den Titel löschen möchten: "
     },
     "FORM": {
-      "TITLE_FORM": "Titel Erstellen",
-      "NEW_TITLE": "Neuer Titel"
+      "TITLE_FORM": "Neuer Titel",
+      "NEW_TITLE": "Titel"
     },
     "MESSAGE": {
       "SUCCESS": "ERFOLG",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -643,8 +643,8 @@
       "CONFIRM_QUESTION": "Are you sure you want to delete the title "
     },
     "FORM": {
-      "TITLE_FORM": "Create Title",
-      "NEW_TITLE": "New Title"
+      "TITLE_FORM": "New Title",
+      "NEW_TITLE": "Title"
     },
     "MESSAGE": {
       "SUCCESS": "SUCCESS",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -639,8 +639,8 @@
       "CONFIRM_QUESTION": "¿Está seguro que desea eliminar "
     },
     "FORM": {
-      "TITLE_FORM": "Crear Título",
-      "NEW_TITLE": "Nuevo Título"
+      "TITLE_FORM": "Nuevo Título",
+      "NEW_TITLE": "Título"
     },
     "MESSAGE": {
       "SUCCESS": "ÉXITO",


### PR DESCRIPTION
- when clicking on “new” button, the cursor must be autmatically in first input  field (FOCUS) 
- when clicking on “new” button, the cancel button should be right of “save”  button (like in edit mode) 
- when clicking on “new” button, rename header to “Neuer Titel” (instead of  “Titel Erstellen” 
- when clicking on “new” button, rename label to “Titel” (instead of “Neuer Titel”) 
- when clicking on “delete” button, rename header to “Titel löschen” (instead of  “Title Löschen”) 
- when clicking on “delete” button, the cancel button should be right of “delete” button