### PR TITLE
fix(table): remove link-like styling from non-first columns and hover tooltips

### DIFF
--- a/src/app/modules/master-data/genaral-table/genaral-table.component.html
+++ b/src/app/modules/master-data/genaral-table/genaral-table.component.html
@@ -128,7 +128,6 @@
           (keydown.enter)="(i === 0 && tableId !== 'ListCustomers' && tableId !== 'DetailCustomer') ? editRegister(row) : onClickRow(row)"
           [class.clickable-title]="i === 0 && tableId !== 'ListCustomers' && tableId !== 'DetailCustomer'"
           [style.cursor]="i === 0 && tableId !== 'ListCustomers' && tableId !== 'DetailCustomer' ? 'pointer' : null"
-          [title]="i === 0 && tableId !== 'ListCustomers' && tableId !== 'DetailCustomer' ? 'Editar' : null"
         >
           @if(col.filter && col.filter.type === 'boolean') {
             @if(row[col.field] == true) {

--- a/src/app/modules/master-data/genaral-table/genaral-table.component.scss
+++ b/src/app/modules/master-data/genaral-table/genaral-table.component.scss
@@ -67,7 +67,11 @@ p-button {
     }
 }
 
-.clickable-title:hover {
+td.clickable-title:hover {
   text-decoration: underline;
   color: #1976d2;
+}
+
+td{
+    user-select: none;
 }


### PR DESCRIPTION
## Changes Made
- Removed link-like styling (underline + pointer cursor) from all columns except the first one
- Eliminated unwanted tooltips/labels appearing on hover
- Preserved clickable styling only for the first action column
- Fixed visual feedback on click (removed focus outlines)

## Technical Details
- Added specific CSS selectors to target non-first columns
- Overrode PrimeNG default styles where necessary
- Maintained accessibility while removing visual distractions