### PR TITLE
Fix center delete modal buttons

### DIFF
--- a/src/app/modules/master-data/components/salutation/components/salutation-modal/salutation-modal.component.html
+++ b/src/app/modules/master-data/components/salutation/components/salutation-modal/salutation-modal.component.html
@@ -33,7 +33,7 @@
             <strong class="stronglock mt-1">"{{ salutationName }}"</strong>?
         </p>
 
-        <div class="flex justify-content-end gap-2">
+        <div class="flex justify-content-center gap-2">
             <p-button type="button" class="delete" size="small" [label]="'BUTTONS.DELETE' | translate"
                 icon="pi pi-trash" iconPos="left" (onClick)="onDeleteConfirm()" severity="danger" [loading]="isLoading"
                 [disabled]="isLoading" />

--- a/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.html
+++ b/src/app/modules/master-data/components/title/components/title-modal/title-modal.component.html
@@ -34,7 +34,7 @@
             <strong class="stronglock mt-1">"{{ titleName }}"</strong>?
         </p>
 
-        <div class="flex justify-content-end gap-2">
+        <div class="flex justify-content-center gap-2">
             <p-button type="button" class="delete" size="small" [label]="'BUTTONS.DELETE' | translate"
                 icon="pi pi-trash" iconPos="left" (onClick)="onDeleteConfirm()" severity="danger" [loading]="isLoading"
                 [disabled]="isLoading" />

--- a/src/app/modules/master-data/components/types-of-companies/components/company-types-modal/company-types-modal.component.html
+++ b/src/app/modules/master-data/components/types-of-companies/components/company-types-modal/company-types-modal.component.html
@@ -40,7 +40,7 @@
             <strong class="stronglock mt-1">"{{ companyTypeName }}"</strong>?
         </p>
 
-        <div class="flex justify-content-end gap-2">
+        <div class="flex justify-content-center gap-2">
             <p-button type="button" class="delete" size="small" [label]="'BUTTONS.DELETE' | translate"
                 icon="pi pi-trash" iconPos="left" (onClick)="onCompnayDeleteConfirm()" severity="danger" [loading]="isLoading"
                 [disabled]="isLoading" />


### PR DESCRIPTION
This update corrects the button alignment in the delete modals for the Titles, Salutation, and Company Types views.

Previously, the buttons were aligned to the side. They are now properly centered, improving visual consistency and user experience.