### PR TITLE
[Fix] Clear contact form when creating new contact in customer detail view

### DIFF
--- a/src/app/modules/customer/components/detail-customer/detail-customer.component.ts
+++ b/src/app/modules/customer/components/detail-customer/detail-customer.component.ts
@@ -220,7 +220,9 @@ export class DetailCustomerComponent implements OnInit, OnDestroy {
 
   createPerson(){
     this.modalType = 'create';
+    this.currentContactPerson = null;
     this.visible = true;
+    this.contactStateService.setCountryToEdit(null);
   }
 
   closeVisibility(visibility: boolean): void {


### PR DESCRIPTION

**Description:**  

**Problem:**  
When clicking "Create New Contact", the form was incorrectly pre-populated with data from the last edited contact due to uncleared state in `currentContactPerson`.

**Changes Made:**  
- Reset `currentContactPerson` to `null` in `createPerson()` method  
- Ensure clean form state for new contact creation  
- Maintain existing edit functionality unchanged  

**Impact:**  
✔️ Better UX with proper empty form for new contacts  
✔️ No side effects on existing edit functionality  
✔️ More intuitive contact management workflow