### PR TITLE
Fix customer creation route and spinner loading separation

### DIFF
--- a/src/app/modules/customer/components/list-customers/list-customers.component.html
+++ b/src/app/modules/customer/components/list-customers/list-customers.component.html
@@ -1,36 +1,30 @@
-<div class="card">
-  <master-data-genaral-table
-    [tableId]="tableKey"
-    [tableValues]="customerListData()"
-    [columns]="selectedColumns"
-    [userPreferences]="userListCustomerPreferences"
-    [dataKeys]="dataKeys"
+<div *ngIf="isLoading" class="spinner-wrapper">
+  <p-progressSpinner class="custom-spinner"></p-progressSpinner>
+</div>
+
+<div class="card" *ngIf="!isLoading">
+  <master-data-genaral-table [tableId]="tableKey" [tableValues]="customerData" [columns]="selectedColumns"
+    [userPreferences]="userListCustomerPreferences" [dataKeys]="dataKeys"
     (onColumnChanges)="onUserListCustomerPreferencesChanges($event)"
     (onRowClickEvent)="goToCustomerOverview($event, $event.originalEvent)"
     (onEditRegister)="goToCustomerDetails($event)"
     (onDeleteRegister)="handleCustomerTableEvents({ type: 'delete', data: $event })"
-    (onCreateRegister)="goToCustomerRegister()"
-  ></master-data-genaral-table>
-  <p-dialog 
-        [header]="('CUSTOMERS.LABELS.DELETE_CUSTOMER' | translate)" 
-        [modal]="true" 
-        [(visible)]="visibleCustomerModal" 
-      >
-        <div class="confirmation-content mb-2 mt-4">
-        <p class="mb-4">
-            {{ 'CUSTOMERS.LABELS.REMOVE_CUSTOMER_QUESTION' | translate }}
-            <strong class="stronglock mt-1">"{{ customerName }}"</strong>?
-        </p>
+    (onCreateRegister)="goToCustomerRegister()"></master-data-genaral-table>
 
-        <div class="flex justify-content-center gap-2">
-            <p-button type="button" class="delete" size="small" [label]="'BUTTONS.DELETE' | translate"
-                icon="pi pi-trash" iconPos="left" (onClick)="onCustomerDeleteConfirm()" severity="danger" [loading]="isLoading"
-                [disabled]="isLoading" />
+  <p-dialog [header]="'CUSTOMERS.LABELS.DELETE_CUSTOMER' | translate" [modal]="true" [(visible)]="visibleCustomerModal">
+    <div class="confirmation-content mb-2 mt-4">
+      <p class="mb-4">
+        {{ 'CUSTOMERS.LABELS.REMOVE_CUSTOMER_QUESTION' | translate }}
+        <strong class="stronglock mt-1">"{{ customerName }}"</strong>?
+      </p>
 
-            <p-button type="button" class="cancel" size="small" [label]="'BUTTONS.CANCEL' | translate"
-                icon="pi pi-times" iconPos="left" (onClick)="this.visibleCustomerModal = false;" [disabled]="isLoading" />
-
-        </div>
+      <div class="flex justify-content-center gap-2">
+        <p-button type="button" class="delete" size="small" [label]="'BUTTONS.DELETE' | translate" icon="pi pi-trash"
+          iconPos="left" (onClick)="onCustomerDeleteConfirm()" severity="danger" [loading]="isLoadingCustomer"
+          [disabled]="isLoadingCustomer" />
+        <p-button type="button" class="cancel" size="small" [label]="'BUTTONS.CANCEL' | translate" icon="pi pi-times"
+          iconPos="left" (onClick)="this.visibleCustomerModal = false;" [disabled]="isLoadingCustomer" />
+      </div>
     </div>
-      </p-dialog>
+  </p-dialog>
 </div>

--- a/src/app/modules/customer/components/list-customers/list-customers.component.scss
+++ b/src/app/modules/customer/components/list-customers/list-customers.component.scss
@@ -1,6 +1,6 @@
 @use 'variables' as *;
 
-p-button{
+p-button {
     color: $primary-light;
 }
 
@@ -8,11 +8,11 @@ p-button{
 .thead {
     background: $primary-color;
     color: #fff;
-    min-width: 1.25rem;//=100px
-  
+    min-width: 1.25rem; //=100px
+
     &:hover {
-      background: $accent-color;
-      color: $primary-dark;
+        background: $accent-color;
+        color: $primary-dark;
     }
 }
 
@@ -21,13 +21,26 @@ p-button{
 }
 
 .thead-input-id {
-    min-width: 4.4rem;//=70px
+    min-width: 4.4rem; //=70px
     width: 100%;
 }
 
 .thead-input-width {
     width: 100%;
 }
+
 .align-right {
     text-align: right;
-  }
+}
+
+.spinner-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 200px;
+}
+
+.custom-spinner {
+    width: 50px;
+    height: 50px;
+}

--- a/src/app/modules/customer/components/list-customers/list-customers.component.ts
+++ b/src/app/modules/customer/components/list-customers/list-customers.component.ts
@@ -1,15 +1,19 @@
 import { Component, OnInit, OnDestroy, ViewChild, inject, computed } from '@angular/core';
-import { Customer } from '../../../../Entities/customer';
-import { CustomerService } from '../../../../Services/customer.service';
-import { Table } from 'primeng/table';
-import { TranslateService, _ } from '@ngx-translate/core';
 import { forkJoin, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { UserPreferenceService } from '../../../../Services/user-preferences.service';
+import { Table } from 'primeng/table';
+import { TranslateService, _ } from '@ngx-translate/core';
+
+// Entities
+import { Customer } from '../../../../Entities/customer';
+import { ContactPerson } from '../../../../Entities/contactPerson';
 import { UserPreference } from '../../../../Entities/user-preference';
+
+// Services
+import { CustomerService } from '../../../../Services/customer.service';
 import { CountryService } from '../../../../Services/country.service';
 import { ContactPersonService } from '../../../../Services/contact-person.service';
-import { ContactPerson } from '../../../../Entities/contactPerson';
+import { UserPreferenceService } from '../../../../Services/user-preferences.service';
 import { CustomerStateService } from '../../utils/customer-state.service';
 import { CustomerUtils } from '../../utils/customer-utils';
 
@@ -77,7 +81,7 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
     private readonly userPreferenceService: UserPreferenceService,
     private readonly router: Router,
     private readonly route: ActivatedRoute
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     forkJoin([
@@ -221,14 +225,14 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
   reloadComponent(self: boolean, urlToNavigateTo?: string) {
     const url = self ? this.router.url : urlToNavigateTo;
     this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
-      this.router.navigate([`/${url}`]).then(() => {});
+      this.router.navigate([`/${url}`]).then(() => { });
     });
   }
 
   goToCustomerDetails(currentCustomer: Customer) {
     this.customerUtils.getCustomerById(currentCustomer.id).subscribe({
       next: (fullCustomer) => {
-        if(fullCustomer){
+        if (fullCustomer) {
           this.customerStateService.setCustomerToEdit(fullCustomer);
         }
       },
@@ -236,7 +240,7 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
         console.error('Error al cargar el customer para editar:', err);
       }
     });
-    
+
     this.router.navigate(['customer-details', currentCustomer.id], {
       relativeTo: this.route,
       state: { customer: currentCustomer.id, customerData: currentCustomer },
@@ -257,7 +261,7 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
 
   onCustomerDeleteConfirm() {
     this.isLoading = true;
-    if(this.selectedCustomer){
+    if (this.selectedCustomer) {
       this.customerUtils.deleteCustomer(this.selectedCustomer).subscribe({
         next: () => {
           this.isLoading = false;

--- a/src/app/modules/customer/components/list-customers/list-customers.component.ts
+++ b/src/app/modules/customer/components/list-customers/list-customers.component.ts
@@ -293,7 +293,7 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
   }
 
   goToCustomerRegister() {
-    this.router.navigate(['customer-details'], { relativeTo: this.route });
+    this.router.navigate(['customer-create'], { relativeTo: this.route });
   }
 
   onCustomerDeleteConfirm() {

--- a/src/app/modules/customer/components/list-customers/list-customers.component.ts
+++ b/src/app/modules/customer/components/list-customers/list-customers.component.ts
@@ -32,32 +32,38 @@ interface Column {
   styleUrl: './list-customers.component.scss',
 })
 export class ListCustomersComponent implements OnInit, OnDestroy {
+  // Dependencies injection
   private readonly customerService = inject(CustomerService);
   private readonly customerStateService = inject(CustomerStateService);
-  private readonly customerUtils = inject(CustomerUtils)
+  private readonly customerUtils = inject(CustomerUtils);
   private readonly countryService = inject(CountryService);
   private readonly contactPersonService = inject(ContactPersonService);
-  readonly customerListData = computed(() => {
-    return this.customerService.customers()
-  });
+  private readonly userPreferenceService = inject(UserPreferenceService);
+  private readonly translate = inject(TranslateService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
-  public cols!: Column[];
-
-  public customers!: Customer[];
-
+  // Table reference
   @ViewChild('dt2') dt2!: Table;
 
+  // Signals & states
+  readonly customerListData = computed(() => this.customerService.customers());
   private langSubscription!: Subscription;
 
+  // Data table
+  customerData: any[] = [];
+  contacts: Record<number, string> = {};
+
+  // Cols configuration
+  public cols!: Column[];
   public selectedColumns!: Column[];
 
+  public customers!: Customer[];
   public countries!: string[];
   public selectedCountries: any[] = [];
 
   public companyTypes: string[] = [];
 
-  customerData: any[] = [];
-  contacts: any = {};
   userListCustomerPreferences: UserPreference = {};
   tableKey: string = 'ListCustomers';
   dataKeys = [
@@ -76,12 +82,7 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
   isLoading = false;
   errorMessage: string = '';
 
-  constructor(
-    private readonly translate: TranslateService,
-    private readonly userPreferenceService: UserPreferenceService,
-    private readonly router: Router,
-    private readonly route: ActivatedRoute
-  ) { }
+  constructor() { }
 
   ngOnInit(): void {
     forkJoin([

--- a/src/app/modules/customer/components/list-customers/list-customers.component.ts
+++ b/src/app/modules/customer/components/list-customers/list-customers.component.ts
@@ -58,29 +58,23 @@ export class ListCustomersComponent implements OnInit, OnDestroy {
   public cols!: Column[];
   public selectedColumns!: Column[];
 
-  public customers!: Customer[];
-  public countries!: string[];
-  public selectedCountries: any[] = [];
-
-  public companyTypes: string[] = [];
-
+  // User Preferences
   userListCustomerPreferences: UserPreference = {};
   tableKey: string = 'ListCustomers';
-  dataKeys = [
-    'id',
-    'companyName',
-    'nameLine2',
-    'kind',
-    'land',
-    'place',
-    'contact',
-  ];
+  dataKeys = ['id', 'companyName', 'nameLine2', 'kind', 'land', 'place', 'contact'];
+
+  // Component States
+  public countries!: string[];
+  public selectedCountries: any[] = [];
+  public companyTypes: string[] = [];
   customerType: 'create' | 'delete' = 'create';
   selectedCustomer: number | null = null;
   customerName: string = '';
   visibleCustomerModal: boolean = false;
   isLoading = false;
   errorMessage: string = '';
+
+  public customers!: Customer[];
 
   constructor() { }
 

--- a/src/app/modules/customer/customer-routing.module.ts
+++ b/src/app/modules/customer/customer-routing.module.ts
@@ -7,9 +7,9 @@ import { PageCustomerComponent } from './components/page-customer/page-customer.
 
 const routes: Routes = [
   { path: '', component: ListCustomersComponent },
-  { path: 'customer-details', component: DetailCustomerComponent },
-  { 
-    path: '', 
+  { path: 'customer-create', component: DetailCustomerComponent },
+  {
+    path: '',
     component: PageCustomerComponent,
     children: [
       {
@@ -21,8 +21,8 @@ const routes: Routes = [
         path: 'customer-details/:id',
         component: DetailCustomerComponent
       },
-      { 
-        path: 'employees/:id', 
+      {
+        path: 'employees/:id',
         loadChildren: () =>
           import('../../modules/employee/employee.module').then(
             (e) => e.EmployeeModule

--- a/src/app/modules/customer/customer.module.ts
+++ b/src/app/modules/customer/customer.module.ts
@@ -22,6 +22,7 @@ import { IconFieldModule } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { InputNumberModule } from 'primeng/inputnumber';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
 
 //Components
 import { ContactComponent } from './components/contact/contact.component';
@@ -65,7 +66,8 @@ import { MasterDataModule } from '../master-data/master-data.module';
     InputIconModule,
     MasterDataModule,
     ToggleSwitchModule,
-    InputNumberModule
+    InputNumberModule,
+    ProgressSpinnerModule
   ],
   providers: [ 
     UserPreferenceService 

--- a/src/app/modules/customer/utils/customer-utils.ts
+++ b/src/app/modules/customer/utils/customer-utils.ts
@@ -15,6 +15,16 @@ export class CustomerUtils {
     private readonly injector = inject(EnvironmentInjector);
 
     /**
+     * Gets all customers without any transformation
+     * @returns Observable emitting the raw list of customers
+     */
+    getAllCustomers(): Observable<Customer[]> {
+        return this.customerService.getAllCustomers().pipe(
+            catchError(() => throwError(() => new Error('Failed to load customers')))
+        );
+    }
+
+    /**
      * Gets a customer by ID with proper error handling
      * @param id - ID of the customer to retrieve
      * @returns Observable emitting the customer or undefined if not found
@@ -124,14 +134,14 @@ export class CustomerUtils {
         if (!customer.id) {
             return throwError(() => new Error('Invalid customer data'));
         }
-    
+
         return new Observable<Customer>(observer => {
             this.customerService.updateCustomer(customer);
-    
+
             runInInjectionContext(this.injector, () => {
                 const sub = this.waitForUpdatedCustomer(customer.id, observer);
                 const errorSub = this.listenForUpdateErrors(observer);
-    
+
                 // Cleanup
                 return () => {
                     sub.unsubscribe();
@@ -155,14 +165,14 @@ export class CustomerUtils {
         });
     }
 
-  private listenForUpdateErrors(observer: any) {
-    return toObservable(this.customerService.error).pipe(
-      filter(error => !!error),
-      take(1)
-    ).subscribe({
-      next: (err) => observer.error(err)
-    });
-  }
+    private listenForUpdateErrors(observer: any) {
+        return toObservable(this.customerService.error).pipe(
+            filter(error => !!error),
+            take(1)
+        ).subscribe({
+            next: (err) => observer.error(err)
+        });
+    }
     /**
  * Gets all contacts for a specific customer by ID
  * @param customerId - ID of the customer to retrieve contacts for


### PR DESCRIPTION
**What this PR does:**
-- Separates the customer creation flow from the detail view by routing to a dedicated path (`/customer-create`) instead of reusing the detail component with a missing ID.
-- Prevents HTTP 500 errors caused by invalid `NaN` ID when creating a new customer.
-- Differentiates `isLoading` spinner for initial data load from `isLoadingCustomer` used when confirming customer deletion.
-- Ensures the customer table updates immediately after deleting a customer.
-- Maintains language change detection for column headers and preferences.

**Why it's needed:**
-- Avoids backend errors and improves user experience when creating new customers.
-- Ensures UI feedback (spinner) is consistent and reflects loading states correctly.
-- Provides a clear separation of creation and edition logic for better maintainability.
