### PR TITLE
feat: support nested field rendering in GeneralTableComponent

### DIFF
--- a/src/app/modules/employee/components/employee-overview/employee-overview.component.ts
+++ b/src/app/modules/employee/components/employee-overview/employee-overview.component.ts
@@ -117,7 +117,7 @@ export class EmployeeOverviewComponent implements OnInit, OnDestroy {
       { field: 'shareholdersince',  type: 'date', header: this.translate.instant(_('EMPLOYEE.TABLE.SH_SINCE_DATE')) },
       { field: 'soleproprietorsince',  type: 'date', header: this.translate.instant(_('EMPLOYEE.TABLE.SP_SINCE_DATE')) },
       { field: 'coentrepreneursince',  type: 'date', header: this.translate.instant(_('EMPLOYEE.TABLE.CE_SINCE_DATE')) },
-      { field: 'qualificationFZ', header: this.translate.instant(_('EMPLOYEE.TABLE.QUALI_FZ')) },
+      { field: 'qualificationFZ.qualification', header: this.translate.instant(_('EMPLOYEE.TABLE.QUALI_FZ')) },
       { field: 'qualificationkmui', header: this.translate.instant(_('EMPLOYEE.TABLE.QUALI_MKUI')) },
 
     ];

--- a/src/app/modules/master-data/genaral-table/genaral-table.component.html
+++ b/src/app/modules/master-data/genaral-table/genaral-table.component.html
@@ -26,9 +26,8 @@
           <p-columnFilter [field]="col.field" matchMode="in" [showMenu]="false">
             <ng-template #filter let-value let-filter="filterCallback">
               <p-multiselect [ngModel]="value" [options]="col.filter.data" (onChange)="filter($event.value)"
-                optionLabel="label" optionValue="value"
-                [placeholder]="'COMMON.ANY' | translate" [style.min-width.rem]="14" [panelStyle]="{ minWidth: '16rem' }"
-                [appendTo]="'body'">
+                optionLabel="label" optionValue="value" [placeholder]="'COMMON.ANY' | translate"
+                [style.min-width.rem]="14" [panelStyle]="{ minWidth: '16rem' }" [appendTo]="'body'">
               </p-multiselect>
             </ng-template>
           </p-columnFilter>
@@ -69,37 +68,40 @@
         <td *ngFor="let col of columns; let i = index" [ngClass]="col.customClasses ? col.customClasses : ''">
           <!-- Add link by an <a> tag -->
           @if(col.routerLink) {
-             <a [routerLink]="col.routerLink(row)" class="clickable-title" (click)="$event.stopPropagation()"
-               style="color: inherit; text-decoration: none;" tabindex="-1">
-               {{ row[col.field] }}
-             </a>
+          <a [routerLink]="col.routerLink(row)" class="clickable-title" (click)="$event.stopPropagation()"
+            style="color: inherit; text-decoration: none;" tabindex="-1">
+            {{ getNestedValue(row, col.field) }}
+          </a>
           } @else if(col.useSameAsEdit) {
-             <p class="clickable-title without-margin" (click)="editRegister(row)" (keydown.enter)="editRegister(row)" >{{row[col.field]}}</p>
+          <p class="clickable-title without-margin" (click)="editRegister(row)" (keydown.enter)="editRegister(row)">
+            {{ getNestedValue(row, col.field) }}
+          </p>
           } @else {
-             <ng-container *ngIf="col.routerLink; else plainText">
-               <a [routerLink]="col.routerLink(row)" (click)="$event.stopPropagation()"
-                 style="color: inherit; text-decoration: none;" tabindex="-1">
-                 {{ row[col.field] }}
-               </a>
-             </ng-container>
-             <ng-template #plainText>
-               <ng-container *ngIf="col.filter && col.filter.type === 'boolean'; else normalText">
-                 <i class="pi" [ngClass]="
+          <ng-container *ngIf="col.routerLink; else plainText">
+            <a [routerLink]="col.routerLink(row)" (click)="$event.stopPropagation()"
+              style="color: inherit; text-decoration: none;" tabindex="-1">
+              {{ getNestedValue(row, col.field) }}
+            </a>
+          </ng-container>
+          <ng-template #plainText>
+            <ng-container *ngIf="col.filter && col.filter.type === 'boolean'; else normalText">
+              <i class="pi" [ngClass]="
                    row[col.field] ? 'text-green-500 pi-check' : 'text-red-500 pi-times'
                  "></i>
-               </ng-container>
-               <ng-template #normalText>
-                 {{
-                 col.type === 'date'
-                 ? col.format ? (row[col.field] | date : col.format) : (row[col.field] | date : defaultDateFormat)
-                 : row[col.field]
-                 }}
-               </ng-template>
-             </ng-template>
+            </ng-container>
+            <ng-template #normalText>
+              {{
+              col.type === 'date'
+              ? col.format ? (getNestedValue(row, col.field) | date : col.format) : (getNestedValue(row, col.field) |
+              date : defaultDateFormat)
+              : getNestedValue(row, col.field)
+              }}
+            </ng-template>
+          </ng-template>
           }
-          
+
         </td>
-        </tr>
+      </tr>
     </ng-template>
 
     <ng-template #emptymessage>

--- a/src/app/modules/master-data/genaral-table/genaral-table.component.ts
+++ b/src/app/modules/master-data/genaral-table/genaral-table.component.ts
@@ -45,17 +45,17 @@ export class GenaralTableComponent implements OnInit, OnChanges, AfterViewChecke
   constructor(
     private readonly translate: TranslateService,
     private readonly messageService: MessageService
-  ){}
+  ) { }
 
   ngAfterViewChecked(): void {
     this.loadStorageData();
   }
 
-  generateBooleanHeaders() : any[] {
+  generateBooleanHeaders(): any[] {
     return [
       {
         value: true,
-        header: this.translate.instant(_('COMMON.YES')) 
+        header: this.translate.instant(_('COMMON.YES'))
       },
       {
         value: false,
@@ -63,10 +63,10 @@ export class GenaralTableComponent implements OnInit, OnChanges, AfterViewChecke
       }
     ];
   }
- 
+
   changeSelect(event: any) {
     if (event.value.length === 0) {
-        this.messageService.add({
+      this.messageService.add({
         severity: 'error',
         summary: this.translate.instant('MESSAGE.ERROR'),
         detail: this.translate.instant('MESSAGE.SELECT_AT_LEAST_ONE')
@@ -125,7 +125,7 @@ export class GenaralTableComponent implements OnInit, OnChanges, AfterViewChecke
     }
   }
 
-  editRegister(register: any){
+  editRegister(register: any) {
     this.onEditRegister.emit(register);
   }
 
@@ -150,21 +150,25 @@ export class GenaralTableComponent implements OnInit, OnChanges, AfterViewChecke
 
   calculateOrderColumns() {
     if (this.columns) {
-       this.colOrders = this.columns.reduce((acc: any, curr: any, index: number) => {
-       acc[curr.field] = index;
-       return acc;
+      this.colOrders = this.columns.reduce((acc: any, curr: any, index: number) => {
+        acc[curr.field] = index;
+        return acc;
       }, {})
     }
   }
 
   processColumnsOrders() {
     const aux = this.userPreferences[this.tableId].displayedColumns;
-    this.userPreferences[this.tableId].displayedColumns = aux.map((column: any) => Object.assign(column, {pos: this.colOrders[column.field]})).sort((a: any, b: any) => a.pos > b.pos);
+    this.userPreferences[this.tableId].displayedColumns = aux.map((column: any) => Object.assign(column, { pos: this.colOrders[column.field] })).sort((a: any, b: any) => a.pos > b.pos);
   }
   loadStorageData() {
     if (!localStorage.getItem(this.dt2.stateKey ?? '')) {
-       this.dt2._filter(); 
+      this.dt2._filter();
     }
+  }
+
+  getNestedValue(obj: any, path: string): any {
+    return path.split('.').reduce((acc, part) => acc?.[part], obj);
   }
 
 }


### PR DESCRIPTION
### Support nested field rendering in GeneralTableComponent

This update enables the GeneralTableComponent to display values from nested object fields (e.g., `qualificationFZ.qualification`) by introducing the `getNestedValue()` utility method. All template bindings that access column values were refactored to use this helper function, ensuring consistent rendering across text, links, booleans, and dates.

Additional changes:
- Replaced all `row[col.field]` references with `getNestedValue(row, col.field)`
- Improved support for dynamic and deeply nested data structures
- Minor cleanup of conditional display logic for columns

This change improves compatibility with complex data models and eliminates the need for flattening data structures in the component logic or services.
