### PR TITLE
Fix modal cancel keep data

### DIFF
--- a/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
+++ b/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
@@ -112,9 +112,6 @@ export class ContractorDetailsComponent implements OnInit, OnChanges, OnDestroy 
         taxno: this.contractor.taxNumber
       });
     }
-    if (this.modalContractType === 'create') {
-      //this.contractorForm.reset();
-    }
   }
 
   private buildContractor(customerSource: any, countrySource: any): Contractor {

--- a/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
+++ b/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
@@ -253,7 +253,6 @@ export class ContractorDetailsComponent implements OnInit, OnChanges, OnDestroy 
 
   closeModal(): void {
     this.isContractVisibleModal.emit(false);
-    this.contractorForm.reset();
   }
 
   removeContractor() {

--- a/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
+++ b/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
@@ -113,7 +113,6 @@ export class ContractorDetailsComponent implements OnInit, OnChanges, OnDestroy 
       });
     }
     if (this.modalContractType === 'create') {
-      this.contractorForm.reset();
     }
   }
 

--- a/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
+++ b/src/app/modules/contractor/components/contractor-details/contractor-details.component.ts
@@ -113,6 +113,7 @@ export class ContractorDetailsComponent implements OnInit, OnChanges, OnDestroy 
       });
     }
     if (this.modalContractType === 'create') {
+      //this.contractorForm.reset();
     }
   }
 

--- a/src/app/modules/customer/components/contact/contact.component.ts
+++ b/src/app/modules/customer/components/contact/contact.component.ts
@@ -198,7 +198,6 @@ export class ContactComponent implements OnInit, OnDestroy, OnChanges {
     this.isSaving = false;
     this.errorMessage = null;
     this.onVisibility.emit(false);
-    this.contactForm.reset();
     this.contactForm.markAsUntouched();
     this.contactForm.markAsPristine();
   }


### PR DESCRIPTION
Updated the behavior of the "Cancel" button and the "X" icon in the "New" modal so that user-entered data is preserved when the modal is closed. When the modal is reopened, previously entered information remains intact, improving user experience and preventing accidental data loss.