### PR TITLE
Fix remove customer subcontract

### DIFF
--- a/src/app/modules/subcontracts/components/subcontracts-detail/subcontract/subcontract.component.html
+++ b/src/app/modules/subcontracts/components/subcontracts-detail/subcontract/subcontract.component.html
@@ -1,15 +1,5 @@
 <form [formGroup]="subcontractForm" (ngSubmit)="onSubmit()">
   <div class="align-items-center mb-2">
-    <div class="order_input order_name mb-2">
-      <label for="customer">{{ 'SUB-CONTRACTS.FORM.CUSTOMER' | translate }}</label>
-      <input
-        pInputText
-        type="text"
-        id="customer"
-        formControlName="customer"
-        autocomplete="off"
-      />
-    </div>
 
     <div class="order_input order_name mb-2">
       <label for="order">{{ 'SUB-CONTRACTS.FORM.ORDER_TITLE' | translate }}</label>

--- a/src/app/modules/subcontracts/components/subcontracts-detail/subcontracts-details.component.html
+++ b/src/app/modules/subcontracts/components/subcontracts-detail/subcontracts-details.component.html
@@ -19,18 +19,8 @@
   <!-- Botones -->
   <div class="buttons mt-4">
     <div class="row">
-      <div class="col-4">
-        <p-button
-          class="order_PDF"
-          size="small"
-          [label]="'BUTTONS.GENERATE_PDF_SUBCONTRACT' | translate"
-          icon="pi pi-file-pdf"
-          iconPos="right"
-          [style]="{ background: '#656565' }"
-        ></p-button>
-      </div>
 
-      <div class="col-8">
+      <div class="form-row flex flex-wrap gap-3 justify-content-center">
         <p-button
           class="Save me-2"
           size="small"

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -384,7 +384,6 @@
   },
   "SUB-CONTRACTS": {
     "FORM": {
-      "CUSTOMER": "Kunde",
       "ORDER_TITLE": "Auftrag",
       "CONTRACTOR": "Auftragnehmer",
       "INVOICE_NUMBER": "Rechnungsnummer",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -385,14 +385,13 @@
   },
   "SUB-CONTRACTS": {
     "FORM": {
-      "CUSTOMER": "Customer",
       "ORDER_TITLE": "Order Title",
       "CONTRACTOR": "Contractor",
       "INVOICE_NUMBER": "Invoice Number",
       "INVOICE_DATE": "Invoice Date",
       "INVOICE_NET_OR_GROSS": "Net or gross",
       "INVOICE_AMOUNT": "Invoice amount",
-      "IS_AFA": "AfA",
+      "IS_AFA": "Drepreciation",
       "AFA_MONTHS": "Depreciation period (months)",
       "DESCRIPTION":"Description"
     },

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -378,7 +378,6 @@
   },
   "SUB-CONTRACTS": {
     "FORM": {
-      "CUSTOMER": "Cliente",
       "ORDER_TITLE": "Título de Orden",
       "CONTRACTOR": "Contratista",
       "INVOICE_NUMBER": "Número de Factura",


### PR DESCRIPTION
This PR removes the "Customer" input field from the Subcontract edit form, as it is no longer required. The corresponding bindings and form control references have been cleaned up to prevent any unused code.