### PR TITLE
Fix delete confirmation translation for Project Sponsor

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -938,7 +938,7 @@
       "ZIP_CITY": "PLZ / Ort"
     },
     "DELETE": {
-      "CONFIRM_QUESTION": "¿Está seguro que desea eliminar el patrocinador del proyecto "
+      "CONFIRM_QUESTION": "Möchten Sie den Projektträger wirklich löschen "
     },
     "MODAL": {
       "NEW": "Neu Projektträger",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -940,7 +940,7 @@
       "ZIP_CITY": "ZIP / City"
     },
     "DELETE": {
-      "CONFIRM_QUESTION": "Möchten Sie den Projektsponsor wirklich löschen "
+      "CONFIRM_QUESTION": "Are you sure you want to delete the project sponsor "
     },
     "MODAL": {
       "NEW": "New Project Sponsor",


### PR DESCRIPTION
Corrects the translation of the delete confirmation message for Project Sponsor in the modal dialog.